### PR TITLE
Add metadata to highlight responses

### DIFF
--- a/src/controllers/highlights.js
+++ b/src/controllers/highlights.js
@@ -5,7 +5,7 @@ import { listTagNamesFromIds } from '#utils/models/tag';
 import { handle404 } from '../errorHandler.js';
 
 const generateHighlight = async quotation => {
-  const { body, authorId, sourceId, tagIds } = quotation;
+  const { body, authorId, sourceId, metadata, tagIds } = quotation;
   const { firstName, lastName } = await findAuthorById(authorId);
   const { title } = await findSourceById(sourceId);
   const tags = await listTagNamesFromIds(tagIds);
@@ -14,6 +14,7 @@ const generateHighlight = async quotation => {
     author: `${firstName} ${lastName}`,
     body,
     source: title,
+    metadata,
     tags
   };
 };

--- a/test/api/router/highlights.test.js
+++ b/test/api/router/highlights.test.js
@@ -22,6 +22,7 @@ test.describe('/highlights', () => {
       {
         author: expect.any(String),
         body: expect.any(String),
+        metadata: expect.any(String),
         source: expect.any(String),
         tags: expect.any(Array)
       }

--- a/test/api/router/random.test.js
+++ b/test/api/router/random.test.js
@@ -13,6 +13,7 @@ test.describe('/random', () => {
     expect(await result.json()).toEqual({
       author: expect.any(String),
       body: expect.any(String),
+      metadata: expect.any(String),
       source: expect.any(String),
       tags: expect.any(Array)
     });


### PR DESCRIPTION
# Description of changes

Add metadata to `/random` and `/highlights` endpoint responses.